### PR TITLE
Update go-socket.io module 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
-	github.com/googollee/go-socket.io v1.6.0
+	github.com/googollee/go-socket.io v1.6.2
 	github.com/joho/godotenv v1.3.0
 	github.com/thingsdb/go-thingsdb v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gomodule/redigo v1.8.4/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
-github.com/googollee/go-socket.io v1.6.0 h1:zbz0kEERgeYL/yEu9pBXSIyZEBluiNc2AJaMFmFjIOY=
-github.com/googollee/go-socket.io v1.6.0/go.mod h1:0vGP8/dXR9SZUMMD4+xxaGo/lohOw3YWMh2WRiWeKxg=
+github.com/googollee/go-socket.io v1.6.2 h1:olKLLHJtHz1IkL/OrTyNriZZvVQYEORNkJAqsOwPask=
+github.com/googollee/go-socket.io v1.6.2/go.mod h1:0vGP8/dXR9SZUMMD4+xxaGo/lohOw3YWMh2WRiWeKxg=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "things-gui",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "ThingsGUI",
   "main": "index.js",
   "repository": {

--- a/react/src/Components/DashboardPage/DashboardPage.js
+++ b/react/src/Components/DashboardPage/DashboardPage.js
@@ -13,7 +13,7 @@ import Typography from '@mui/material/Typography';
 import {TopBar} from '../Navigation';
 import DashboardContent from './DashboardContent';
 
-const version='version: 1.1.9';
+const version='version: 1.1.10';
 
 const Transition = React.forwardRef((props, ref) => {
     return <Slide direction="down" ref={ref} {...props} mountOnEnter unmountOnExit />;

--- a/things-gui.go
+++ b/things-gui.go
@@ -13,7 +13,7 @@ import (
 )
 
 // AppVersion exposes version information
-const AppVersion = "1.1.9"
+const AppVersion = "1.1.10"
 
 var cookieName = "uid"
 var cookieMaxAge = 6048000 // (seconds) 10 weeks


### PR DESCRIPTION
Update go-socket.io module: https://github.com/googollee/go-socket.io/releases/tag/v1.6.2